### PR TITLE
Feature/Improve RecordedTime Safety

### DIFF
--- a/ACFTCalculator/Sources/ACFTCalculator/Models/RecordedTime.swift
+++ b/ACFTCalculator/Sources/ACFTCalculator/Models/RecordedTime.swift
@@ -10,9 +10,23 @@ public struct RecordedTime {
 
     // MARK: Initialization
 
-    public init(minutes: Int, seconds: Int) {
-        self.minutes = minutes
-        self.seconds = seconds
+    /// Attempts creating a new instance of `RecordedTime`. Initialization will fail if the value for `seconds` is greater than 59.
+    /// - Parameters:
+    ///   - minutes: The number of minutes.
+    ///   - seconds: The number of seconds. Must be between 0...59.
+    public init?(minutes: UInt, seconds: UInt) {
+        guard (0 ... 59).contains(seconds) else {
+            return nil
+        }
+        self.minutes = Int(minutes)
+        self.seconds = Int(seconds)
+    }
+
+    /// Creates a new instance of `RecordedTime` by converting the `seconds` into minutes and seconds.
+    /// - Parameter seconds: The number of seconds.
+    public init(seconds: UInt) {
+        self.minutes = Int(seconds / 60)
+        self.seconds = Int(seconds % 60)
     }
 }
 
@@ -38,13 +52,12 @@ extension RecordedTime: StringInitializable {
         guard
             components.count == 2,
             let firstComponent = components.first,
-            let minutes = Int(firstComponent),
+            let minutes = UInt(firstComponent),
             let secondComponent = components.last,
-            let seconds = Int(secondComponent) else {
+            let seconds = UInt(secondComponent) else {
             return nil
         }
 
-        self.minutes = minutes
-        self.seconds = seconds
+        self.init(minutes: minutes, seconds: seconds)
     }
 }

--- a/ACFTCalculator/Tests/ACFTCalculatorTests/ACFTCalculatorTests.swift
+++ b/ACFTCalculator/Tests/ACFTCalculatorTests/ACFTCalculatorTests.swift
@@ -137,7 +137,7 @@ final class ACFTCalculatorTests: XCTestCase {
 
         // Use a time value that is explicitly listed on the CSV.
         // 3:00 minutes should equate to 60 points.
-        let time = RecordedTime(minutes: 3, seconds: 0)
+        let time = try XCTUnwrap(RecordedTime(minutes: 3, seconds: 0))
         XCTAssertTrue(calculator.sprintDragCarryTimes.map { $0.value }.contains(time))
 
         let points = calculator.calculatePoints(for: .sprintDragCarry(time: time))
@@ -149,7 +149,7 @@ final class ACFTCalculatorTests: XCTestCase {
 
         // Use a time value that is faster than the fasted listed time.
         // 1:33 is the fastest value, so use one that is faster than that.
-        let time = RecordedTime(minutes: 0, seconds: 30)
+        let time = try XCTUnwrap(RecordedTime(minutes: 0, seconds: 30))
         let fastestTimeValue = try XCTUnwrap(calculator.sprintDragCarryTimes.last?.value)
         XCTAssertLessThan(time, fastestTimeValue)
 
@@ -162,7 +162,7 @@ final class ACFTCalculatorTests: XCTestCase {
 
         // Use a time value that is slower than the slowest listed time.
         // 3:35 is the slowest value, so use one that is slower than that.
-        let time = RecordedTime(minutes: 10, seconds: 0)
+        let time = try XCTUnwrap(RecordedTime(minutes: 10, seconds: 0))
         let slowestTimeValue = try XCTUnwrap(calculator.sprintDragCarryTimes.last?.value)
         XCTAssertGreaterThan(time, slowestTimeValue)
 
@@ -217,7 +217,7 @@ final class ACFTCalculatorTests: XCTestCase {
 
         // Use a time value that is explicitly listed on the CSV.
         // 2:09 minutes should equate to 60 points.
-        let time = RecordedTime(minutes: 2, seconds: 9)
+        let time = try XCTUnwrap(RecordedTime(minutes: 2, seconds: 9))
         XCTAssertTrue(calculator.plankTimes.map { $0.value }.contains(time))
 
         let points = calculator.calculatePoints(for: .plank(time: time))
@@ -229,7 +229,7 @@ final class ACFTCalculatorTests: XCTestCase {
 
         // Use a time value that is longer than the longest listed time.
         // 4:20 is the longest listed value, so use one that is longer than that.
-        let time = RecordedTime(minutes: 5, seconds: 0)
+        let time = try XCTUnwrap(RecordedTime(minutes: 5, seconds: 0))
         let longestTimeValue = try XCTUnwrap(calculator.plankTimes.first?.value)
         XCTAssertGreaterThan(time, longestTimeValue)
 
@@ -242,7 +242,7 @@ final class ACFTCalculatorTests: XCTestCase {
 
         // Use a time value that is shorte than the shortest listed time.
         // 2:03 is the shortest listed value, so use one that is shorter than that.
-        let time = RecordedTime(minutes: 1, seconds: 0)
+        let time = try XCTUnwrap(RecordedTime(minutes: 1, seconds: 0))
         let shortestTimeValue = try XCTUnwrap(calculator.plankTimes.last?.value)
         XCTAssertLessThan(time, shortestTimeValue)
 
@@ -257,7 +257,7 @@ final class ACFTCalculatorTests: XCTestCase {
 
         // Use a time value that is explicitly listed on the CSV.
         // 21:00 minutes should equate to 60 points.
-        let time = RecordedTime(minutes: 21, seconds: 0)
+        let time = try XCTUnwrap(RecordedTime(minutes: 21, seconds: 0))
         XCTAssertTrue(calculator.twoMileRunTimes.map { $0.value }.contains(time))
 
         let points = calculator.calculatePoints(for: .twoMileRun(time: time))
@@ -269,7 +269,7 @@ final class ACFTCalculatorTests: XCTestCase {
 
         // Use a time value that is faster than the fasted listed time.
         // 13:30 is the fastest value, so use one that is faster than that.
-        let time = RecordedTime(minutes: 12, seconds: 30)
+        let time = try XCTUnwrap(RecordedTime(minutes: 12, seconds: 30))
         let fastestTimeValue = try XCTUnwrap(calculator.twoMileRunTimes.first?.value)
         XCTAssertLessThan(time, fastestTimeValue)
 
@@ -282,7 +282,7 @@ final class ACFTCalculatorTests: XCTestCase {
 
         // Use a time value that is slower than the slowest listed time.
         // 22:48 is the slowest value, so use one that is slower than that.
-        let time = RecordedTime(minutes: 23, seconds: 0)
+        let time = try XCTUnwrap(RecordedTime(minutes: 23, seconds: 0))
         let slowestTimeValue = try XCTUnwrap(calculator.twoMileRunTimes.last?.value)
         XCTAssertGreaterThan(time, slowestTimeValue)
 

--- a/ACFTCalculator/Tests/ACFTCalculatorTests/RecordedTimeTests.swift
+++ b/ACFTCalculator/Tests/ACFTCalculatorTests/RecordedTimeTests.swift
@@ -6,17 +6,40 @@ import XCTest
 final class RecordedTimeTests: XCTestCase {
     // MARK: Tests
 
-    func testComparableConformance() {
+    func testComparableConformance() throws {
         // Verify comparing times when minutes differ.
-        XCTAssertLessThan(RecordedTime(minutes: 1, seconds: 30),
-                          RecordedTime(minutes: 10, seconds: 30))
+        XCTAssertLessThan(try XCTUnwrap(RecordedTime(minutes: 1, seconds: 30)),
+                          try XCTUnwrap(RecordedTime(minutes: 10, seconds: 30)))
 
         // Verify comparing times when minutes are equal but seconds differ.
-        XCTAssertLessThan(RecordedTime(minutes: 10, seconds: 29),
-                          RecordedTime(minutes: 10, seconds: 30))
+        XCTAssertLessThan(try XCTUnwrap(RecordedTime(minutes: 10, seconds: 29)),
+                          try XCTUnwrap(RecordedTime(minutes: 10, seconds: 30)))
 
         // Verify comparing equal times.
-        XCTAssertEqual(RecordedTime(minutes: 1, seconds: 30),
-                       RecordedTime(minutes: 1, seconds: 30))
+        XCTAssertEqual(try XCTUnwrap(RecordedTime(minutes: 1, seconds: 30)),
+                       try XCTUnwrap(RecordedTime(minutes: 1, seconds: 30)))
+    }
+
+    func testMinutesAndSecondsInitReturnsNilForInvalidSecondsValue() {
+        // Verify passing a seconds value past 59 seconds will return nil.
+        XCTAssertNil(RecordedTime(minutes: 1, seconds: 60))
+    }
+
+    func testSecondsInitCorrectlyCalculatesMinutesAndSeconds() {
+        let zeroValue = RecordedTime(seconds: 0)
+        XCTAssertEqual(zeroValue.minutes, 0)
+        XCTAssertEqual(zeroValue.seconds, 0)
+
+        let valueUnderAMinute = RecordedTime(seconds: 59)
+        XCTAssertEqual(valueUnderAMinute.minutes, 0)
+        XCTAssertEqual(valueUnderAMinute.seconds, 59)
+
+        let valueWithoutSeconds = RecordedTime(seconds: 120)
+        XCTAssertEqual(valueWithoutSeconds.minutes, 2)
+        XCTAssertEqual(valueWithoutSeconds.seconds, 0)
+
+        let valueWithSeconds = RecordedTime(seconds: 125)
+        XCTAssertEqual(valueWithSeconds.minutes, 2)
+        XCTAssertEqual(valueWithSeconds.seconds, 5)
     }
 }


### PR DESCRIPTION
- Made the original minutes/seconds initializer optional to catch invalid values passed in for seconds
- Added a non-optional initializer using only seconds
- Updated both initializers to use `Uint` as a stop-gap for negative values 