### PR TITLE
Feature/Alternate Events

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,16 @@ do {
     
     // Two-Mile Run (2MR)
     _ = calculator.calculatePoints(for: .twoMileRun(time: RecordedTime(seconds: 810)))
+    
+    // Alternate Events
+    // 1K Meter Swim
+    _ = calculator.calculatePoints(for: .oneThousandMeterSwim(time: RecordedTime(seconds: 1500)))
+    
+    // 12K Meter Stationary Bike
+    _ = calculator.calculatePoints(for: .twelveThousandMeterBike(time: RecordedTime(seconds: 1500)))
+        
+    // 5K Meter Row
+    _ = calculator.calculatePoints(for: .fiveThousandMeterRow(time: RecordedTime(seconds: 1500)))
 } catch {
     print(error)
 }

--- a/Sources/ACFTCalculator/Models/ACFTCalculator.swift
+++ b/Sources/ACFTCalculator/Models/ACFTCalculator.swift
@@ -11,6 +11,11 @@ public final class ACFTCalculator {
         case legTuck(repetitions: Int)
         case plank(time: RecordedTime)
         case twoMileRun(time: RecordedTime)
+
+        // Alternate Events
+        case oneThousandMeterSwim(time: RecordedTime)
+        case twelveThousandMeterBike(time: RecordedTime)
+        case fiveThousandMeterRow(time: RecordedTime)
     }
 
     // MARK: Properties
@@ -110,6 +115,10 @@ public final class ACFTCalculator {
             return self.calculatePoints(forValue: time,
                                         pointsMapping: self.twoMileRunTimes,
                                         order: .ascending)
+        case .oneThousandMeterSwim(let time),
+                .twelveThousandMeterBike(let time),
+                .fiveThousandMeterRow(let time):
+            return self.calculatePointsForAlternateEvent(time: time)
         }
     }
 
@@ -137,6 +146,18 @@ public final class ACFTCalculator {
             continue
         }
         return 0
+    }
+
+    /// Calculates the number of points earned in an alternate ACFT event (i.e. swim, bike, or row) based on the input value.
+    /// - Parameter time: The time recorded by the user for a given alternate event.
+    /// - Returns: The number of points (0-100) the given input correlates to.
+    private func calculatePointsForAlternateEvent(time: RecordedTime) -> Int {
+        // At time of writing, the alternate events (see https://www.army.mil/acft/#faq-section-4)
+        // do not have a published scoring chart but one is said to be in the works.
+        // The allotted time is 25 minutes for each alternate event and a passing score of 60 points
+        // is awarded so long as the soldier completes the event in those 25 minutes.
+        let allowedTime = RecordedTime(seconds: 1500) // 25 minutes
+        return time <= allowedTime ? 60 : 0
     }
 }
 

--- a/Sources/ACFTCalculator/Models/ACFTCalculator.swift
+++ b/Sources/ACFTCalculator/Models/ACFTCalculator.swift
@@ -115,9 +115,9 @@ public final class ACFTCalculator {
             return self.calculatePoints(forValue: time,
                                         pointsMapping: self.twoMileRunTimes,
                                         order: .ascending)
-        case .oneThousandMeterSwim(let time),
-                .twelveThousandMeterBike(let time),
-                .fiveThousandMeterRow(let time):
+        case let .oneThousandMeterSwim(time),
+             let .twelveThousandMeterBike(time),
+             let .fiveThousandMeterRow(time):
             return self.calculatePointsForAlternateEvent(time: time)
         }
     }

--- a/Tests/ACFTCalculatorTests/ACFTCalculatorTests.swift
+++ b/Tests/ACFTCalculatorTests/ACFTCalculatorTests.swift
@@ -289,4 +289,109 @@ final class ACFTCalculatorTests: XCTestCase {
         let points = calculator.calculatePoints(for: .twoMileRun(time: time))
         XCTAssertEqual(points, 0)
     }
+
+    // MARK: 1K Meter Swim Calculator Tests
+
+    func testCalculatingOneThousandMeterSwimPointsForTimeLessThanAllottedTimeReturnsPassingScore() throws {
+        let calculator = try ACFTCalculator()
+
+        // Use a time that is less than the allotted time (25 minutes).
+        let time = try XCTUnwrap(RecordedTime(minutes: 15, seconds: 00))
+
+        // Verify a pass score of 60 is returned.
+        let points = calculator.calculatePoints(for: .oneThousandMeterSwim(time: time))
+        XCTAssertEqual(points, 60)
+    }
+
+    func testCalculatingOneThousandMeterSwimPointsForTimeEqualToAllottedTimeReturnsPassingScore() throws {
+        let calculator = try ACFTCalculator()
+
+        // Use a time that is equal to the allotted time (25 minutes).
+        let time = try XCTUnwrap(RecordedTime(minutes: 25, seconds: 00))
+
+        // Verify a pass score of 60 is returned.
+        let points = calculator.calculatePoints(for: .oneThousandMeterSwim(time: time))
+        XCTAssertEqual(points, 60)
+    }
+
+    func testCalculatingOneThousandMeterSwimPointsForTimeGreaterThanAllottedTimeReturnsFailingScore() throws {
+        let calculator = try ACFTCalculator()
+
+        // Use a time that is greater than the allotted time (25 minutes).
+        let time = try XCTUnwrap(RecordedTime(minutes: 25, seconds: 1))
+
+        // Verify a failing score of 0 is returned.
+        let points = calculator.calculatePoints(for: .oneThousandMeterSwim(time: time))
+        XCTAssertEqual(points, 0)
+    }
+
+    // MARK: 12K Meter Bike Calculator Tests
+
+    func testCalculatingTwelveThousandMeterBikePointsForTimeLessThanAllottedTimeReturnsPassingScore() throws {
+        let calculator = try ACFTCalculator()
+
+        // Use a time that is less than the allotted time (25 minutes).
+        let time = try XCTUnwrap(RecordedTime(minutes: 15, seconds: 00))
+
+        // Verify a pass score of 60 is returned.
+        let points = calculator.calculatePoints(for: .twelveThousandMeterBike(time: time))
+        XCTAssertEqual(points, 60)
+    }
+
+    func testCalculatingTwelveThousandMeterBikePointsForTimeEqualToAllottedTimeReturnsPassingScore() throws {
+        let calculator = try ACFTCalculator()
+
+        // Use a time that is equal to the allotted time (25 minutes).
+        let time = try XCTUnwrap(RecordedTime(minutes: 25, seconds: 00))
+
+        // Verify a pass score of 60 is returned.
+        let points = calculator.calculatePoints(for: .twelveThousandMeterBike(time: time))
+        XCTAssertEqual(points, 60)
+    }
+
+    func testCalculatingTwelveThousandMeterBikePointsForTimeGreaterThanAllottedTimeReturnsFailingScore() throws {
+        let calculator = try ACFTCalculator()
+
+        // Use a time that is greater than the allotted time (25 minutes).
+        let time = try XCTUnwrap(RecordedTime(minutes: 25, seconds: 1))
+
+        // Verify a failing score of 0 is returned.
+        let points = calculator.calculatePoints(for: .twelveThousandMeterBike(time: time))
+        XCTAssertEqual(points, 0)
+    }
+
+    // MARK: 5K Meter Row Calculator Tests
+
+    func testCalculatingFiveThousandMeterRowPointsForTimeLessThanAllottedTimeReturnsPassingScore() throws {
+        let calculator = try ACFTCalculator()
+
+        // Use a time that is less than the allotted time (25 minutes).
+        let time = try XCTUnwrap(RecordedTime(minutes: 15, seconds: 00))
+
+        // Verify a pass score of 60 is returned.
+        let points = calculator.calculatePoints(for: .fiveThousandMeterRow(time: time))
+        XCTAssertEqual(points, 60)
+    }
+
+    func testCalculatingFiveThousandMeterRowPointsForTimeEqualToAllottedTimeReturnsPassingScore() throws {
+        let calculator = try ACFTCalculator()
+
+        // Use a time that is equal to the allotted time (25 minutes).
+        let time = try XCTUnwrap(RecordedTime(minutes: 25, seconds: 00))
+
+        // Verify a pass score of 60 is returned.
+        let points = calculator.calculatePoints(for: .fiveThousandMeterRow(time: time))
+        XCTAssertEqual(points, 60)
+    }
+
+    func testCalculatingFiveThousandMeterRowPointsForTimeGreaterThanAllottedTimeReturnsFailingScore() throws {
+        let calculator = try ACFTCalculator()
+
+        // Use a time that is greater than the allotted time (25 minutes).
+        let time = try XCTUnwrap(RecordedTime(minutes: 25, seconds: 1))
+
+        // Verify a failing score of 0 is returned.
+        let points = calculator.calculatePoints(for: .fiveThousandMeterRow(time: time))
+        XCTAssertEqual(points, 0)
+    }
 }

--- a/codecov.yml
+++ b/codecov.yml
@@ -29,4 +29,4 @@ comment:
   require_changes: no # if true: only post the comment if coverage changes
 
 ignore:
-  - "ACFTCalculator/Tests/**"  # Ignore actual test files from being included in test reports.
+  - "Tests/**"  # Ignore actual test files from being included in test reports.


### PR DESCRIPTION
Added support for the following alternate events for soldiers on permanent profile:
- 1K Meter Swim
- 12K Meter Stationary Bike
- 5K Meter Row

Couple things to note:
- At this time, there appears to be no established score charts for the alternate events, but one is said to be in the works (according to the [Army's videos on the alternate events](https://www.youtube.com/playlist?list=PL7Wkp7VPLbap7JmWkdTYqp-YSgnNLWBgi))
- While the Army's Youtube channel lists a 15K Meter Stationary Bike as an alternate event (posted in 2019), the [ACFT website](https://www.army.mil/acft/#faq-section-4) states the alternate event is a 12K bike (as does this [official Army blog post](https://www.army.mil/article/248055/u_s_army_training_and_doctrine_command_g357_sergeant_major_shares_personal_acft_experience))
